### PR TITLE
refactor: consolidate uploader server configuration and handlers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Create and publish a Docker image to ghcr
 
 env:
-  GO_VERSION: '1.24.3'
+  GO_VERSION: '1.25.8'
   REGISTRY: ghcr.io
 
 on:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests with Chainsaw
 
 env:
-  GO_VERSION: '1.24.3'
+  GO_VERSION: '1.25.8'
 
 on:
   pull_request:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  GO_VERSION: '1.24.3'
+  GO_VERSION: '1.25.8'
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ bin/
 
 # ignore pub directory
 pub/
+
+.claude/settings.local.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,85 +1,67 @@
-version: "1"
-
+version: "2"
 run:
   timeout: 5m
   allow-parallel-runners: true
   issues-exit-code: 1
   tests: true
-  skip-dirs:
-    - bin
-    - dist
-    - vendor
-
-output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude-use-default: false
-  exclude-rules:
-    - path: ".*_test\\.go$"
-      linters:
-        - errcheck
-        - gosec
-        - dupl
-    - path: "uploader/.*"
-      linters:
-        - lll
-    - path: "main\\.go$"
-      linters:
-        - gochecknoinits
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - copyloopvar
+    - dupl
     - errcheck
-    - gci
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
+    - lll
     - misspell
     - nakedret
+    - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-    - wsl
-
-linters-settings:
-  revive:
+    - wsl_v5
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: import-shadowing
+    gocyclo:
+      min-complexity: 15
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
     rules:
-      - name: comment-spacings
-      - name: package-comments
-      - name: exported
-        arguments: ["sayRepetitiveInsteadOfStutters"]
-      
-  gci:
-    sections:
-      - standard
-      - blank
-      - dot
-      - default
-      - prefix(github.com/KubeRocketCI)
-      - prefix(github.com/KubeRocketCI/krci-cache)
-    skip-generated: true
-    custom-order: true
-    
-  gocyclo:
-    min-complexity: 15
-    
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-    
-  misspell:
-    locale: US
+      - linters:
+          - lll
+        path: uploader/.*
+      - linters:
+          - errcheck
+          - dupl
+          - lll
+        path: _test\.go
+    paths:
+      - bin
+      - dist
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - bin
+      - dist
+      - third_party$
+      - builtin$
+      - examples$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,35 +86,37 @@ make clean-all
 
 ### Server Configuration
 The server uses environment-based configuration with these key variables:
-- `UPLOADER_HOST`, `UPLOADER_PORT`: Server binding
-- `UPLOADER_DIRECTORY`: Upload directory (default: ./pub)
-- `UPLOADER_UPLOAD_CREDENTIALS`: Basic auth (format: username:password)
-- `UPLOADER_MAX_UPLOAD_SIZE`: Regular file size limit
-- `UPLOADER_MAX_CONCURRENT_UPLOADS`: Concurrency limit
-- `UPLOADER_REQUEST_TIMEOUT`: Request timeout
+- `UPLOADER_HOST`, `UPLOADER_PORT`: Server binding (defaults: `localhost`, `8080`)
+- `UPLOADER_DIRECTORY`: Upload directory (default: `./pub`)
+- `UPLOADER_UPLOAD_CREDENTIALS`: Basic auth (format: `username:password`); when unset, all endpoints are anonymous
+- `UPLOADER_MAX_UPLOAD_SIZE`: Maximum request body size enforced by `middleware.BodyLimit` (default: `8GB`; accepts suffixes like `100M`, `2G`)
+- `UPLOADER_SHUTDOWN_TIMEOUT`: Maximum time to wait for in-flight requests during graceful shutdown (default: `10m`; Go `time.ParseDuration` syntax)
 
 ### Security Features
-- Path traversal protection via `isPathSafe()` functions
-- Basic HTTP authentication for protected endpoints
-- Tar.gz extraction with size limits (2GB per file, 8GB total)
-- Symlink and hard link prevention in archives
-- Context-aware operations with cancellation support
+- Path traversal protection on every mutating endpoint: target must lie strictly inside the upload directory (sibling-prefix escapes like `/data` vs `/data-evil` are rejected — see `TestUploadSiblingPrefixTraversal`)
+- Basic HTTP authentication for protected endpoints; only `POST /upload`, `DELETE /upload`, `DELETE /delete` require credentials
+- Tar.gz extraction with streaming size limits (`MaxFileSize` 2GB per file, `MaxTotalSize` 8GB total) enforced via `trackingWriter`
+- Symlink and hard link entries in archives are rejected outright
+- Request body size limit via `middleware.BodyLimit` (`UPLOADER_MAX_UPLOAD_SIZE`)
 
 ### API Endpoints
-- `GET /health`: Health check with JSON response
+- `GET /health`: Health check with JSON response (always anonymous)
 - `POST /upload`: File upload with explicit tar.gz extraction (requires `targz=true` form parameter)
 - `DELETE /upload`: Single file deletion
-- `DELETE /delete`: Bulk deletion of old files
-- `HEAD /:path`: File metadata and caching headers
-- `GET /*`: Static file serving
+- `DELETE /delete`: Bulk deletion of files older than `days`
+- `HEAD /:path`: File metadata and caching headers (`Last-Modified`)
+- `GET /*`: Static file serving via `http.FileServer` (range/conditional GET/sendfile-backed on Linux)
 
-**Important**: Tar.gz extraction only occurs when explicitly requested with `targz=true` form parameter. Files with `.tar.gz` extension are stored as regular files unless this flag is set.
+**Important**: Tar.gz extraction only occurs when `targz=true` is sent as a form parameter. Files whose names end in `.tar.gz` are stored as regular files unless this flag is set.
 
 ### Concurrency Model
-- Semaphore-based upload limiting (`uploadSem` channel)
-- Context-aware operations for cancellation
-- Graceful shutdown with configurable timeout
-- Structured JSON logging with request tracing
+The request path holds no shared mutable state and uses no application-level locks (no `sync.Mutex`, no semaphore, no in-memory index). Concurrency is governed at the kernel level:
+- `http.Server.ReadHeaderTimeout` (10s) and `IdleTimeout` (120s) defend against slow clients without truncating legitimate large transfers. `ReadTimeout`/`WriteTimeout` are deliberately left at zero so they cannot abort multi-GB uploads/downloads.
+- `middleware.BodyLimit` (`UPLOADER_MAX_UPLOAD_SIZE`) enforces a hard cap on request body size with one integer comparison per request.
+- Graceful shutdown is triggered by `SIGINT`/`SIGTERM`; the server stops accepting new connections and waits up to `UPLOADER_SHUTDOWN_TIMEOUT` for in-flight requests to drain.
+- Static downloads use `http.FileServer` and benefit from `sendfile(2)` zero-copy on Linux; no userspace involvement in the byte loop.
+
+Future phases will add atomic publish via temp-file-plus-rename (single-file uploads) and directory-rename (tar uploads) to extend integrity guarantees to concurrent writers on the same path. These additions remain lock-free.
 
 ## Testing Strategy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.title="krci-cache" \
 # Install required packages with version pinning
 RUN apk add --no-cache \
     tar=1.35-r4 \
-    rsync=3.4.1-r1 \
+    rsync=3.4.2-r0 \
     && rm -rf /var/cache/apk/*
 
 # Copy the pre-built binary from dist folder

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(DIST_DIR):
 	mkdir -p $(DIST_DIR)
 
 # Tool Versions
-GOLANGCI_LINT_VERSION ?= v1.64.7
+GOLANGCI_LINT_VERSION ?= v2.8.0
 CHAINSAW_VERSION ?= v0.2.12
 KIND_VERSION ?= v0.29.0
 KUSTOMIZE_VERSION ?= v5.6.0
@@ -64,7 +64,7 @@ install-tools: golangci-lint chainsaw kind kustomize ## Download all tools local
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: fmt
 fmt: ## Run go fmt against code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KubeRocketCI/krci-cache
 
-go 1.24.3
+go 1.25.8
 
 require (
 	github.com/labstack/echo/v4 v4.13.4

--- a/uploader/untar.go
+++ b/uploader/untar.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +55,7 @@ func setupExtraction(dst string, r io.Reader) (string, *gzip.Reader, error) {
 // closeGzipReader safely closes the gzip reader
 func closeGzipReader(gzr *gzip.Reader) {
 	if closeErr := gzr.Close(); closeErr != nil {
-		fmt.Printf("warning: failed to close gzip reader: %v\n", closeErr)
+		log.Printf("warning: failed to close gzip reader: %v", closeErr)
 	}
 }
 
@@ -117,21 +118,17 @@ func processEntry(header *tar.Header, target string, tr *tar.Reader, totalWritte
 		return fmt.Errorf("symlinks and hard links are not allowed: %s", header.Name)
 
 	default:
-		fmt.Printf("warning: skipping unsupported file type %d for %s\n", header.Typeflag, header.Name)
+		log.Printf("warning: skipping unsupported file type %d for %s", header.Typeflag, header.Name)
 	}
 
 	return nil
 }
 
-// isPathSafe checks if the target path is within the destination directory
-func isPathSafe(target, dst string) bool {
-	absTarget, err := filepath.Abs(target)
-	if err != nil {
-		return false
-	}
-
-	// Ensure the target is within the destination directory
-	return strings.HasPrefix(absTarget, dst+string(filepath.Separator)) || absTarget == dst
+// isPathSafe reports whether absTarget equals absRoot or is a strict descendant.
+// Both arguments must already be absolute; the trailing separator in the prefix
+// check rejects sibling-prefix escapes (e.g. "/data" vs "/data-evil").
+func isPathSafe(absTarget, absRoot string) bool {
+	return absTarget == absRoot || strings.HasPrefix(absTarget, absRoot+string(filepath.Separator))
 }
 
 // handleDirectory creates a directory with proper permissions
@@ -175,7 +172,7 @@ func handleRegularFile(target string, header *tar.Header, tr *tar.Reader, curren
 
 	defer func() {
 		if closeErr := f.Close(); closeErr != nil {
-			fmt.Printf("warning: failed to close file %s: %v\n", target, closeErr)
+			log.Printf("warning: failed to close file %s: %v", target, closeErr)
 		}
 	}()
 

--- a/uploader/untar_test.go
+++ b/uploader/untar_test.go
@@ -16,6 +16,7 @@ import (
 func TestUntarGz(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create test tar.gz data
@@ -51,11 +52,13 @@ func TestUntarGz(t *testing.T) {
 func TestUntarGz_MemoryOptimizedSizeValidation(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-memory")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create tar.gz with multiple moderate-sized files
 	// The key test is that we don't pre-allocate huge amounts of memory
 	var buf bytes.Buffer
+
 	gzw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gzw)
 
@@ -102,11 +105,13 @@ func TestUntarGz_MemoryOptimizedSizeValidation(t *testing.T) {
 func TestUntarGz_ActualSizeTracking(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-size-tracking")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create multiple files that are reasonably sized
 	// This tests that our size tracking works correctly with real data
 	var buf bytes.Buffer
+
 	gzw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gzw)
 
@@ -157,10 +162,12 @@ func TestUntarGz_TotalSizeLimit(t *testing.T) {
 
 	tempdir, err := os.MkdirTemp("", "test-untar-size-limit")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create a small archive but use custom trackingWriter to simulate reaching the limit
 	var buf bytes.Buffer
+
 	gzw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gzw)
 
@@ -230,6 +237,7 @@ func TestTrackingWriter(t *testing.T) {
 func TestUntarGzInvalidData(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-invalid")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Test with invalid gzip data
@@ -244,6 +252,7 @@ func TestUntarGzInvalidData(t *testing.T) {
 func TestUntarGzPathTraversal(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-traversal")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create malicious tar.gz with path traversal
@@ -258,6 +267,7 @@ func TestUntarGzPathTraversal(t *testing.T) {
 func TestUntarGzSymlinkRejection(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-symlink")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create tar.gz with symlink
@@ -272,10 +282,12 @@ func TestUntarGzSymlinkRejection(t *testing.T) {
 func TestUntarGzFileSizeLimit(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-size-limit")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create an archive with a single file that exceeds individual file size limit
 	var buf bytes.Buffer
+
 	gzw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gzw)
 
@@ -303,6 +315,7 @@ func TestUntarGzFileSizeLimit(t *testing.T) {
 func TestUntarGzTotalSizeLimit(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-total-size-limit")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Test the validateTotalSize function with edge cases
@@ -324,6 +337,7 @@ func TestUntarGzTotalSizeLimit(t *testing.T) {
 func TestUntarGzDirectoryPermissions(t *testing.T) {
 	tempdir, err := os.MkdirTemp("", "test-untar-perms")
 	require.NoError(t, err)
+
 	defer os.RemoveAll(tempdir)
 
 	// Create a tar.gz with specific directory permissions
@@ -343,6 +357,7 @@ func TestUntarGzDirectoryPermissions(t *testing.T) {
 // Helper function to create basic test tar.gz
 func createTestTarGz(t *testing.T) []byte {
 	var buf bytes.Buffer
+
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
 
@@ -390,6 +405,7 @@ func createTestTarGz(t *testing.T) []byte {
 // Helper function to create malicious tar.gz with path traversal
 func createMaliciousTarGz(t *testing.T) []byte {
 	var buf bytes.Buffer
+
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
 
@@ -416,6 +432,7 @@ func createMaliciousTarGz(t *testing.T) []byte {
 // Helper function to create tar.gz with symlink
 func createSymlinkTarGz(t *testing.T) []byte {
 	var buf bytes.Buffer
+
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
 
@@ -440,6 +457,7 @@ func createSymlinkTarGz(t *testing.T) []byte {
 // Helper function to create tar.gz with specific directory permissions
 func createPermissionsTarGz(t *testing.T) []byte {
 	var buf bytes.Buffer
+
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
 

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -2,15 +2,21 @@
 package uploader
 
 import (
+	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"log"
 	"mime/multipart"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -18,69 +24,69 @@ import (
 )
 
 var (
-	// Default configuration values
 	host      = "localhost"
 	port      = "8080"
 	directory = "./pub"
+	// absRootDir is the resolved absolute form of `directory`, cached at startup
+	// so the per-request hot path (safeJoin) does no Abs syscalls. Always update
+	// it via setUploadDirectory to keep the two vars consistent.
+	absRootDir string
 )
 
-// Simple upload handler based on go-simple-uploader pattern
+// setUploadDirectory updates both `directory` and the cached `absRootDir` so
+// safeJoin sees a consistent view. Returns an error if the path cannot be
+// resolved to an absolute form.
+func setUploadDirectory(dir string) error {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("invalid upload directory %q: %w", dir, err)
+	}
+
+	directory = dir
+	absRootDir = abs
+
+	return nil
+}
+
+// safeJoin resolves rel inside the upload directory and returns its absolute
+// path. The trailing-separator check in isPathSafe rejects sibling-prefix
+// escapes such as "/data" vs "/data-evil".
+func safeJoin(rel string) (string, error) {
+	abspath := filepath.Join(absRootDir, rel)
+
+	if !isPathSafe(abspath, absRootDir) {
+		return "", echo.NewHTTPError(http.StatusForbidden, "DENIED: path escapes upload directory")
+	}
+
+	return abspath, nil
+}
+
 func upload(c echo.Context) error {
-	// Get the uploaded file - using Echo's simple method like go-simple-uploader
 	file, err := c.FormFile("file")
 	if err != nil {
 		return err
 	}
 
-	// Get form parameters
 	untargz := c.FormValue("targz")
 	path := c.FormValue("path")
 
-	// Use filename if no path specified
 	if path == "" {
 		path = file.Filename
 	}
 
-	// Directory traversal detection (same as go-simple-uploader)
-	savepath := filepath.Join(directory, path)
-	abspath, _ := filepath.Abs(savepath)
-	absuploaddir, _ := filepath.Abs(directory)
-
-	if !strings.HasPrefix(abspath, absuploaddir) {
-		return echo.NewHTTPError(http.StatusForbidden, "DENIED: You should not upload outside the upload directory.")
+	abspath, err := safeJoin(path)
+	if err != nil {
+		return err
 	}
 
-	// Handle tar.gz extraction
 	if untargz == "true" {
-		return handleTarGzUpload(c, file, path, savepath, abspath)
-	}
-
-	// Handle regular file upload
-	return handleRegularUpload(c, file, path, savepath)
-}
-
-// handleTarGzUpload handles tar.gz file extraction
-func handleTarGzUpload(c echo.Context, file *multipart.FileHeader, path, savepath, abspath string) error {
-	if err := os.MkdirAll(savepath, 0o755); err != nil {
-		return err
-	}
-
-	// Re-open file for tar extraction (same pattern as go-simple-uploader)
-	src, err := file.Open()
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if closeErr := src.Close(); closeErr != nil {
-			fmt.Printf("Error closing tar source file: %v\n", closeErr)
+		if err := extractTarGz(file, abspath); err != nil {
+			return err
 		}
-	}()
-
-	err = UntarGz(abspath, src)
-	if err != nil {
-		fmt.Println(err.Error())
-		return err
+	} else {
+		if err := saveRegularFile(file, abspath); err != nil {
+			return err
+		}
 	}
 
 	return c.JSON(http.StatusCreated, map[string]interface{}{
@@ -91,9 +97,11 @@ func handleTarGzUpload(c echo.Context, file *multipart.FileHeader, path, savepat
 	})
 }
 
-// handleRegularUpload handles regular file uploads
-func handleRegularUpload(c echo.Context, file *multipart.FileHeader, path, savepath string) error {
-	// Open the uploaded file
+func extractTarGz(file *multipart.FileHeader, abspath string) error {
+	if err := os.MkdirAll(abspath, 0o755); err != nil {
+		return err
+	}
+
 	src, err := file.Open()
 	if err != nil {
 		return err
@@ -101,60 +109,62 @@ func handleRegularUpload(c echo.Context, file *multipart.FileHeader, path, savep
 
 	defer func() {
 		if closeErr := src.Close(); closeErr != nil {
-			fmt.Printf("Error closing source file: %v\n", closeErr)
+			log.Printf("error closing tar source file: %v", closeErr)
 		}
 	}()
 
-	// Create directory if needed
-	if _, err := os.Stat(savepath); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(savepath), 0o755); err != nil {
-			return err
-		}
+	return UntarGz(abspath, src)
+}
+
+func saveRegularFile(file *multipart.FileHeader, abspath string) error {
+	src, err := file.Open()
+	if err != nil {
+		return err
 	}
 
-	dst, err := os.Create(savepath)
+	defer func() {
+		if closeErr := src.Close(); closeErr != nil {
+			log.Printf("error closing source file: %v", closeErr)
+		}
+	}()
+
+	if err := os.MkdirAll(filepath.Dir(abspath), 0o755); err != nil {
+		return err
+	}
+
+	dst, err := os.Create(abspath)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
 		if closeErr := dst.Close(); closeErr != nil {
-			fmt.Printf("Error closing destination file: %v\n", closeErr)
+			log.Printf("error closing destination file: %v", closeErr)
 		}
 	}()
 
-	// Simple copy operation (same as go-simple-uploader)
-	if _, err = io.Copy(dst, src); err != nil {
-		return err
-	}
+	_, err = io.Copy(dst, src)
 
-	return c.JSON(http.StatusCreated, map[string]interface{}{
-		"message":  fmt.Sprintf("File has been uploaded to %s", path),
-		"filename": file.Filename,
-		"path":     path,
-		"size":     file.Size,
-	})
+	return err
 }
 
-// Simple delete handler
 func uploaderDelete(c echo.Context) error {
 	path := c.FormValue("path")
 
-	// Directory traversal detection
-	savePath := filepath.Join(directory, path)
-	abspath, _ := filepath.Abs(savePath)
-	absoluteUploadDir, _ := filepath.Abs(directory)
-
-	if !strings.HasPrefix(abspath, absoluteUploadDir) {
-		return echo.NewHTTPError(http.StatusForbidden, "DENIED: You should not upload outside the upload directory.")
+	abspath, err := safeJoin(path)
+	if err != nil {
+		return err
 	}
 
 	if _, err := os.Stat(abspath); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "Could not find your file")
+		if errors.Is(err, fs.ErrNotExist) {
+			return echo.NewHTTPError(http.StatusNotFound, "Could not find your file")
+		}
+
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Could not stat your file: %s", err.Error()))
 	}
 
-	err := os.RemoveAll(abspath)
-	if err != nil {
+	if err := os.RemoveAll(abspath); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Could not delete your file: %s", err.Error()))
 	}
 
@@ -164,7 +174,6 @@ func uploaderDelete(c echo.Context) error {
 	})
 }
 
-// Health check handler
 func healthCheck(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"status":    "healthy",
@@ -173,20 +182,19 @@ func healthCheck(c echo.Context) error {
 	})
 }
 
-// Simple last modified handler
 func lastModified(c echo.Context) error {
-	path := c.Param("path")
-	filePath := filepath.Join(directory, path)
-	abspath, _ := filepath.Abs(filePath)
-	absoluteUploadDir, _ := filepath.Abs(directory)
-
-	if !strings.HasPrefix(abspath, absoluteUploadDir) {
-		return echo.NewHTTPError(http.StatusForbidden, "DENIED: You should not try to get outside the root directory.")
+	abspath, err := safeJoin(c.Param("path"))
+	if err != nil {
+		return err
 	}
 
 	info, err := os.Stat(abspath)
 	if err != nil {
-		return echo.NotFoundHandler(c)
+		if errors.Is(err, fs.ErrNotExist) {
+			return echo.NotFoundHandler(c)
+		}
+
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to stat file")
 	}
 
 	c.Response().Header().Set(echo.HeaderLastModified, info.ModTime().UTC().Format(http.TimeFormat))
@@ -194,36 +202,22 @@ func lastModified(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-// Simple delete old files handler
 func deleteOldFilesOfDir(c echo.Context) error {
 	path := c.FormValue("path")
 	days, _ := strconv.Atoi(c.FormValue("days"))
-	recursiveFlag := c.FormValue("recursive")
+	recursive := c.FormValue("recursive") == "true"
 
-	if len(recursiveFlag) == 0 {
-		recursiveFlag = "false"
-	}
-
-	recursive, err := strconv.ParseBool(recursiveFlag)
+	abspath, err := safeJoin(path)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid recursive parameter")
-	}
-
-	filePath := filepath.Join(directory, path)
-	abspath, _ := filepath.Abs(filePath)
-	absoluteUploadDir, _ := filepath.Abs(directory)
-
-	if !strings.HasPrefix(abspath, absoluteUploadDir) {
-		return echo.NewHTTPError(http.StatusForbidden, "DENIED: You should not try to get outside the root directory.")
-	}
-
-	_, err = os.Stat(abspath)
-	if err != nil {
-		return echo.NotFoundHandler(c)
+		return err
 	}
 
 	files, err := findFilesOlderThanXDays(abspath, days, recursive)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return echo.NotFoundHandler(c)
+		}
+
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find old files")
 	}
 
@@ -241,7 +235,7 @@ func deleteOldFilesOfDir(c echo.Context) error {
 	for _, file := range files {
 		filePath := filepath.Join(abspath, file.Name())
 		if err := os.Remove(filePath); err != nil {
-			fmt.Printf("Failed to delete file %s: %v\n", file.Name(), err)
+			log.Printf("failed to delete file %s: %v", file.Name(), err)
 			continue
 		}
 
@@ -283,61 +277,163 @@ func findFilesOlderThanXDays(dir string, days int, recursive bool) (files []os.F
 	return files, nil
 }
 
-// Uploader starts the simplified upload server based on go-simple-uploader pattern
+// Default server tunables. Only header- and idle-level timeouts are set; body
+// read/write timeouts are deliberately left at zero so they cannot truncate
+// legitimate multi-GB cache transfers under slow clients or slow disks.
+const (
+	defaultMaxUploadSize   = "8GB"
+	defaultShutdownTimeout = 10 * time.Minute
+	readHeaderTimeout      = 10 * time.Second
+	idleTimeout            = 120 * time.Second
+	healthPath             = "/health"
+)
+
+type serverConfig struct {
+	maxUploadSize   string
+	shutdownTimeout time.Duration
+	credentials     string
+}
+
+func loadConfig() (serverConfig, error) {
+	dir := directory
+	if v := os.Getenv("UPLOADER_DIRECTORY"); v != "" {
+		dir = v
+	}
+
+	if v := os.Getenv("UPLOADER_HOST"); v != "" {
+		host = v
+	}
+
+	if v := os.Getenv("UPLOADER_PORT"); v != "" {
+		port = v
+	}
+
+	cfg := serverConfig{
+		maxUploadSize:   defaultMaxUploadSize,
+		shutdownTimeout: defaultShutdownTimeout,
+	}
+
+	if v := os.Getenv("UPLOADER_UPLOAD_CREDENTIALS"); v != "" {
+		if _, _, ok := strings.Cut(v, ":"); !ok {
+			return cfg, fmt.Errorf("UPLOADER_UPLOAD_CREDENTIALS must use 'username:password' format")
+		}
+
+		cfg.credentials = v
+	}
+
+	if v := os.Getenv("UPLOADER_MAX_UPLOAD_SIZE"); v != "" {
+		cfg.maxUploadSize = v
+	}
+
+	if v := os.Getenv("UPLOADER_SHUTDOWN_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid UPLOADER_SHUTDOWN_TIMEOUT %q: %w", v, err)
+		}
+
+		cfg.shutdownTimeout = d
+	}
+
+	if err := setUploadDirectory(dir); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}
+
+// registerAuth mirrors go-simple-uploader: only mutating endpoints require creds.
+// rawCreds is assumed validated by loadConfig (contains ":"). The expected
+// username/password are converted to bytes once so the per-request validator is
+// allocation-free.
+func registerAuth(e *echo.Echo, rawCreds string) {
+	if rawCreds == "" {
+		return
+	}
+
+	user, pass, _ := strings.Cut(rawCreds, ":")
+	expectedUser := []byte(user)
+	expectedPass := []byte(pass)
+
+	c := middleware.DefaultBasicAuthConfig
+	c.Skipper = func(ctx echo.Context) bool {
+		if ctx.Path() == healthPath {
+			return true
+		}
+
+		method := ctx.Request().Method
+
+		return method == http.MethodHead || method == http.MethodGet
+	}
+	c.Validator = func(username, password string, _ echo.Context) (bool, error) {
+		if subtle.ConstantTimeCompare([]byte(username), expectedUser) == 1 &&
+			subtle.ConstantTimeCompare([]byte(password), expectedPass) == 1 {
+			return true, nil
+		}
+
+		return false, nil
+	}
+	e.Use(middleware.BasicAuthWithConfig(c))
+}
+
+func runWithGracefulShutdown(e *echo.Echo, addr string, shutdownTimeout time.Duration) error {
+	serverErr := make(chan error, 1)
+
+	go func() {
+		if err := e.Start(addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+			return
+		}
+
+		serverErr <- nil
+	}()
+
+	stop := make(chan os.Signal, 1)
+
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(stop)
+
+	select {
+	case err := <-serverErr:
+		return err
+	case sig := <-stop:
+		log.Printf("received signal %s, shutting down (timeout=%s)", sig, shutdownTimeout)
+
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+
+		return e.Shutdown(ctx)
+	}
+}
+
+// Uploader starts the upload server and blocks until SIGINT/SIGTERM.
 func Uploader() error {
-	// Load configuration from environment
-	if os.Getenv("UPLOADER_DIRECTORY") != "" {
-		directory = os.Getenv("UPLOADER_DIRECTORY")
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
 	}
 
-	if os.Getenv("UPLOADER_HOST") != "" {
-		host = os.Getenv("UPLOADER_HOST")
-	}
-
-	if os.Getenv("UPLOADER_PORT") != "" {
-		port = os.Getenv("UPLOADER_PORT")
-	}
-
-	// Create simple Echo instance like go-simple-uploader
 	e := echo.New()
+	e.HideBanner = true
+	e.Server.ReadHeaderTimeout = readHeaderTimeout
+	e.Server.IdleTimeout = idleTimeout
 
-	// Only essential middleware
-	e.Use(middleware.Logger())
+	// Recover first so it catches panics in any later middleware. Logger wraps
+	// BodyLimit so 413 rejections are still logged.
 	e.Use(middleware.Recover())
+	e.Use(middleware.Logger())
+	e.Use(middleware.BodyLimit(cfg.maxUploadSize))
+	registerAuth(e, cfg.credentials)
 
-	// Routes
 	e.Static("/", directory)
-	e.GET("/health", healthCheck)
+	e.GET(healthPath, healthCheck)
 	e.HEAD("/:path", lastModified)
 	e.POST("/upload", upload)
 	e.DELETE("/upload", uploaderDelete)
 	e.DELETE("/delete", deleteOldFilesOfDir)
 
-	// Simple auth setup (same pattern as go-simple-uploader)
-	if os.Getenv("UPLOADER_UPLOAD_CREDENTIALS") != "" {
-		creds := strings.Split(os.Getenv("UPLOADER_UPLOAD_CREDENTIALS"), ":")
-		c := middleware.DefaultBasicAuthConfig
-		c.Skipper = func(c echo.Context) bool {
-			if c.Path() == "/health" {
-				return true
-			}
+	addr := fmt.Sprintf("%s:%s", host, port)
+	log.Printf("krci-cache listening on %s (directory=%s, max_upload=%s, shutdown_timeout=%s)",
+		addr, directory, cfg.maxUploadSize, cfg.shutdownTimeout)
 
-			if (c.Request().Method == "HEAD" || c.Request().Method == "GET") && c.Path() != "/upload" && c.Path() != "/delete" {
-				return true
-			}
-
-			return false
-		}
-		c.Validator = func(username, password string, c echo.Context) (bool, error) {
-			if subtle.ConstantTimeCompare([]byte(username), []byte(creds[0])) == 1 &&
-				subtle.ConstantTimeCompare([]byte(password), []byte(strings.Join(creds[1:], ":"))) == 1 {
-				return true, nil
-			}
-
-			return false, nil
-		}
-		e.Use(middleware.BasicAuthWithConfig(c))
-	}
-
-	return e.Start(fmt.Sprintf("%s:%s", host, port))
+	return runWithGracefulShutdown(e, addr, cfg.shutdownTimeout)
 }

--- a/uploader/uploader_test.go
+++ b/uploader/uploader_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -23,16 +24,14 @@ func setupTestServer(t *testing.T) (*echo.Echo, string) {
 	tempdir, err := os.MkdirTemp("", "uploader-test-*")
 	require.NoError(t, err)
 
-	// Set the directory variable for tests
 	originalDir := directory
-	directory = tempdir
 
-	// Create simple Echo instance like the main Uploader() function
+	require.NoError(t, setUploadDirectory(tempdir))
+
 	e := echo.New()
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 
-	// Routes
 	e.Static("/", directory)
 	e.GET("/health", healthCheck)
 	e.HEAD("/:path", lastModified)
@@ -41,7 +40,7 @@ func setupTestServer(t *testing.T) (*echo.Echo, string) {
 	e.DELETE("/delete", deleteOldFilesOfDir)
 
 	t.Cleanup(func() {
-		directory = originalDir
+		_ = setUploadDirectory(originalDir)
 
 		os.RemoveAll(tempdir)
 	})
@@ -137,6 +136,52 @@ func TestUploadDirectoryTraversal(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "DENIED")
 }
 
+// TestUploadSiblingPrefixTraversal guards the bug where HasPrefix without the
+// path separator allowed escape to a sibling directory whose name happens to
+// begin with the upload dir name (e.g. upload dir "/data" matched "/data-evil").
+func TestUploadSiblingPrefixTraversal(t *testing.T) {
+	parent, err := os.MkdirTemp("", "uploader-prefix-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(parent) })
+
+	uploadDir := filepath.Join(parent, "data")
+	siblingDir := filepath.Join(parent, "data-evil")
+
+	require.NoError(t, os.Mkdir(uploadDir, 0o755))
+	require.NoError(t, os.Mkdir(siblingDir, 0o755))
+
+	originalDir := directory
+
+	require.NoError(t, setUploadDirectory(uploadDir))
+
+	t.Cleanup(func() {
+		_ = setUploadDirectory(originalDir)
+	})
+
+	e := echo.New()
+	e.POST("/upload", upload)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "pwned.txt")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("should not land in sibling"))
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteField("path", "../data-evil/pwned.txt"))
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code, "must reject sibling-prefix escape")
+
+	_, statErr := os.Stat(filepath.Join(siblingDir, "pwned.txt"))
+	assert.True(t, os.IsNotExist(statErr), "file must not have been written to sibling dir")
+}
+
 func TestDeleteFile(t *testing.T) {
 	e, tempdir := setupTestServer(t)
 
@@ -164,62 +209,66 @@ func TestDeleteFile(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestEnvironmentConfiguration(t *testing.T) {
-	// Test that environment variables are read correctly
-	originalDir := os.Getenv("UPLOADER_DIRECTORY")
-	originalHost := os.Getenv("UPLOADER_HOST")
-	originalPort := os.Getenv("UPLOADER_PORT")
+// saveServerGlobals snapshots the package-level `directory`, `host`, and
+// `port` (which `loadConfig` mutates as side effects) and registers a cleanup
+// that restores them. Restoring `directory` via `setUploadDirectory` keeps
+// `absRootDir` consistent with it.
+func saveServerGlobals(t *testing.T) {
+	t.Helper()
 
-	defer func() {
-		// Restore original values
-		if originalDir != "" {
-			os.Setenv("UPLOADER_DIRECTORY", originalDir)
-		} else {
-			os.Unsetenv("UPLOADER_DIRECTORY")
-		}
+	originalDir, originalHost, originalPort := directory, host, port
 
-		if originalHost != "" {
-			os.Setenv("UPLOADER_HOST", originalHost)
-		} else {
-			os.Unsetenv("UPLOADER_HOST")
-		}
+	t.Cleanup(func() {
+		_ = setUploadDirectory(originalDir)
+		host = originalHost
+		port = originalPort
+	})
+}
 
-		if originalPort != "" {
-			os.Setenv("UPLOADER_PORT", originalPort)
-		} else {
-			os.Unsetenv("UPLOADER_PORT")
-		}
-	}()
+func TestLoadConfig(t *testing.T) {
+	saveServerGlobals(t)
 
-	// Set test environment variables
-	testDir := "/test/upload/dir"
-	testHost := "test-host"
-	testPort := "9999"
+	tempdir := t.TempDir()
 
-	os.Setenv("UPLOADER_DIRECTORY", testDir)
-	os.Setenv("UPLOADER_HOST", testHost)
-	os.Setenv("UPLOADER_PORT", testPort)
+	t.Setenv("UPLOADER_DIRECTORY", tempdir)
+	t.Setenv("UPLOADER_HOST", "test-host")
+	t.Setenv("UPLOADER_PORT", "9999")
+	t.Setenv("UPLOADER_UPLOAD_CREDENTIALS", "user:pass")
+	t.Setenv("UPLOADER_MAX_UPLOAD_SIZE", "100M")
+	t.Setenv("UPLOADER_SHUTDOWN_TIMEOUT", "30s")
 
-	// Reset global variables
-	directory = "./pub" // default
-	host = "localhost"  // default
-	port = "8080"       // default
+	cfg, err := loadConfig()
+	require.NoError(t, err)
 
-	// This would be called in the Uploader() function
-	if os.Getenv("UPLOADER_DIRECTORY") != "" {
-		directory = os.Getenv("UPLOADER_DIRECTORY")
-	}
+	assert.Equal(t, tempdir, directory)
+	assert.Equal(t, "test-host", host)
+	assert.Equal(t, "9999", port)
 
-	if os.Getenv("UPLOADER_HOST") != "" {
-		host = os.Getenv("UPLOADER_HOST")
-	}
+	expectedAbs, err := filepath.Abs(tempdir)
+	require.NoError(t, err)
+	assert.Equal(t, expectedAbs, absRootDir)
 
-	if os.Getenv("UPLOADER_PORT") != "" {
-		port = os.Getenv("UPLOADER_PORT")
-	}
+	assert.Equal(t, "user:pass", cfg.credentials)
+	assert.Equal(t, "100M", cfg.maxUploadSize)
+	assert.Equal(t, 30*time.Second, cfg.shutdownTimeout)
+}
 
-	// Check that values were set correctly
-	assert.Equal(t, testDir, directory)
-	assert.Equal(t, testHost, host)
-	assert.Equal(t, testPort, port)
+func TestLoadConfigRejectsBadCredentials(t *testing.T) {
+	saveServerGlobals(t)
+
+	t.Setenv("UPLOADER_UPLOAD_CREDENTIALS", "missing-colon")
+
+	_, err := loadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UPLOADER_UPLOAD_CREDENTIALS")
+}
+
+func TestLoadConfigRejectsBadShutdownTimeout(t *testing.T) {
+	saveServerGlobals(t)
+
+	t.Setenv("UPLOADER_SHUTDOWN_TIMEOUT", "not-a-duration")
+
+	_, err := loadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UPLOADER_SHUTDOWN_TIMEOUT")
 }


### PR DESCRIPTION
Streamline HTTP handler logic by splitting the upload endpoint into focused tar extraction and regular file save helpers, eliminating parameter sprawl and JSON response duplication.

Consolidate environment configuration via loadConfig() and serverConfig struct. Add graceful shutdown support with configurable timeout and proper signal handling.

Improve error handling consistency: distinguishing ENOENT from other I/O errors in uploaderDelete and lastModified (matching deleteOldFilesOfDir pattern). Unify logging across files (fmt.Printf -> log.Printf).

Extract shared patterns: saveServerGlobals() test helper to dedupe cleanup code, healthPath constant to couple route and auth skipper.

Update CI/CD tooling: Go 1.24.3 -> 1.25.8, golangci-lint v1 -> v2 with updated configuration.
