### PR TITLE
feat: implement atomic publish with last-writer-wins concurrency safety

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.8
 require (
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.38.0
 )
 
 require (
@@ -17,7 +18,6 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/uploader/concurrent_test.go
+++ b/uploader/concurrent_test.go
@@ -1,0 +1,401 @@
+package uploader
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Builds the same route table as Uploader() so tests exercise production dispatch.
+func concurrencyServer(t *testing.T) (*echo.Echo, string) {
+	t.Helper()
+
+	tempdir := withStagingDir(t)
+	require.NoError(t, setupStagingDir())
+
+	e := echo.New()
+	e.HideBanner = true
+	registerRoutes(e, http.FileServer(hideStagingFS{root: http.Dir(tempdir)}))
+
+	return e, tempdir
+}
+
+func buildUploadRequest(t *testing.T, path string, content []byte, tarFlag string) *http.Request {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+
+	part, err := w.CreateFormFile("file", filepath.Base(path))
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+
+	require.NoError(t, w.WriteField("path", path))
+
+	if tarFlag != "" {
+		require.NoError(t, w.WriteField("targz", tarFlag))
+	}
+
+	require.NoError(t, w.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	return req
+}
+
+// Production clients (curl -F) send DELETE bodies as multipart; net/http
+// silently ignores urlencoded bodies on DELETE.
+func buildDeleteRequest(t *testing.T, url string, fields map[string]string) *http.Request {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+
+	for k, v := range fields {
+		require.NoError(t, w.WriteField(k, v))
+	}
+
+	require.NoError(t, w.Close())
+
+	req := httptest.NewRequest(http.MethodDelete, url, body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	return req
+}
+
+func TestConcurrentWritersSameFile(t *testing.T) {
+	e, tempdir := concurrencyServer(t)
+
+	const writers = 16
+
+	// 256 KiB is large enough that direct os.Create would interleave Writes.
+	const size = 256 * 1024
+
+	// Single-byte-repeat per writer makes torn writes trivially detectable.
+	contents := make([][]byte, writers)
+	for i := range contents {
+		b := make([]byte, size)
+		for j := range b {
+			b[j] = byte('A' + i)
+		}
+
+		contents[i] = b
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(writers)
+
+	for i := 0; i < writers; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			req := buildUploadRequest(t, "race.bin", contents[i], "")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusCreated, rec.Code, "writer %d failed: %s", i, rec.Body.String())
+		}(i)
+	}
+
+	wg.Wait()
+
+	got, err := os.ReadFile(filepath.Join(tempdir, "race.bin"))
+	require.NoError(t, err)
+	require.Len(t, got, size, "final file must be exactly one writer's content size")
+
+	// Every byte must equal the first byte: confirms no interleaving.
+	first := got[0]
+	for i, b := range got {
+		require.Equalf(t, first, b, "byte %d differs from byte 0 (0x%02x vs 0x%02x) — torn write!", i, b, first)
+	}
+
+	// And the chosen content must match exactly one of the writers' inputs.
+	chosen := -1
+
+	for i, c := range contents {
+		if bytes.Equal(c, got) {
+			chosen = i
+			break
+		}
+	}
+
+	require.NotEqualf(t, -1, chosen, "final file matches no writer's input — should be impossible")
+	t.Logf("winner: writer %d", chosen)
+}
+
+func TestReaderDuringWriter(t *testing.T) {
+	e, _ := concurrencyServer(t)
+
+	old := bytes.Repeat([]byte("O"), 4096)
+	newer := bytes.Repeat([]byte("N"), 4096)
+	oldHash := sha256.Sum256(old)
+	newHash := sha256.Sum256(newer)
+
+	// Seed an "old" version first.
+	{
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, buildUploadRequest(t, "live.bin", old, ""))
+		require.Equal(t, http.StatusCreated, rec.Code)
+	}
+
+	// Slow-upload the new version.
+	var (
+		writerDone sync.WaitGroup
+		reads      atomic.Int64
+		torn       atomic.Int64
+	)
+
+	writerDone.Add(1)
+
+	go func() {
+		defer writerDone.Done()
+
+		body := &bytes.Buffer{}
+		w := multipart.NewWriter(body)
+		part, err := w.CreateFormFile("file", "live.bin")
+		require.NoError(t, err)
+
+		// Write into the multipart body slowly so the publish takes
+		// measurable wall-clock time — that gives the reader goroutine
+		// plenty of overlapping requests to expose torn reads.
+		for _, c := range newer {
+			_, _ = part.Write([]byte{c})
+
+			time.Sleep(20 * time.Microsecond)
+		}
+
+		require.NoError(t, w.WriteField("path", "live.bin"))
+		require.NoError(t, w.Close())
+
+		req := httptest.NewRequest(http.MethodPost, "/upload", body)
+		req.Header.Set("Content-Type", w.FormDataContentType())
+
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	}()
+
+	// Spam GETs while the writer runs. Every 200 OK must hash to either
+	// oldHash or newHash; anything else means the reader saw a partial
+	// publish (the invariant we're protecting).
+	stop := make(chan struct{})
+
+	go func() {
+		writerDone.Wait()
+		// Let a few more reads happen after publish lands.
+		time.Sleep(5 * time.Millisecond)
+		close(stop)
+	}()
+
+	for {
+		select {
+		case <-stop:
+			t.Logf("reads=%d torn=%d", reads.Load(), torn.Load())
+			require.Zero(t, torn.Load(), "reader observed partial content")
+
+			return
+		default:
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/live.bin", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			continue
+		}
+
+		reads.Add(1)
+
+		got := sha256.Sum256(rec.Body.Bytes())
+		if got != oldHash && got != newHash {
+			torn.Add(1)
+			t.Errorf("torn read: hash=%s len=%d", hex.EncodeToString(got[:]), rec.Body.Len())
+		}
+	}
+}
+
+// Entries all start with `tag` so concurrent-extract tests can identify the winner.
+func makeTarGz(t *testing.T, tag string, fileCount int) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for i := 0; i < fileCount; i++ {
+		content := []byte(fmt.Sprintf("%s/file-%d-content", tag, i))
+		hdr := &tar.Header{
+			Name:     fmt.Sprintf("%s-%d.txt", tag, i),
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return buf.Bytes()
+}
+
+func TestConcurrentTarExtractSameDir(t *testing.T) {
+	e, tempdir := concurrencyServer(t)
+
+	const filesPerArchive = 30
+
+	arcA := makeTarGz(t, "A", filesPerArchive)
+	arcB := makeTarGz(t, "B", filesPerArchive)
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	for _, arc := range [][]byte{arcA, arcB} {
+		go func(content []byte) {
+			defer wg.Done()
+
+			req := buildUploadRequest(t, "release", content, "true")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+		}(arc)
+	}
+
+	wg.Wait()
+
+	entries, err := os.ReadDir(filepath.Join(tempdir, "release"))
+	require.NoError(t, err)
+	require.Len(t, entries, filesPerArchive, "directory must hold exactly one archive's entries")
+
+	// Either every entry is from A or every entry is from B. Mixed = bug.
+	prefix := strings.SplitN(entries[0].Name(), "-", 2)[0]
+	require.Contains(t, []string{"A", "B"}, prefix)
+
+	for _, e := range entries {
+		require.Truef(t, strings.HasPrefix(e.Name(), prefix+"-"),
+			"entry %s does not match winner prefix %s — interleaved extract!", e.Name(), prefix)
+	}
+
+	t.Logf("winner: archive %s", prefix)
+}
+
+func TestStagingDirHiddenFromStaticServe(t *testing.T) {
+	e, tempdir := concurrencyServer(t)
+
+	stage := filepath.Join(tempdir, stagingDir)
+	require.NoError(t, os.MkdirAll(stage, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stage, "secret.txt"), []byte("nope"), 0o644))
+
+	// GET .tmp/secret.txt
+	{
+		req := httptest.NewRequest(http.MethodGet, "/.tmp/secret.txt", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	}
+
+	// HEAD on a single-segment .tmp also rejected.
+	{
+		req := httptest.NewRequest(http.MethodHead, "/.tmp", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "HEAD on .tmp must be rejected by safeJoin")
+	}
+}
+
+// Without this guard, a client could DELETE /upload path=.tmp/up-XXXX to
+// disrupt another client's in-flight upload.
+func TestStagingDirRejectedFromMutatingHandlers(t *testing.T) {
+	e, _ := concurrencyServer(t)
+
+	// POST /upload with path inside .tmp
+	{
+		req := buildUploadRequest(t, ".tmp/evil.txt", []byte("x"), "")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+
+	// DELETE /upload with path inside .tmp (multipart, matching production)
+	{
+		req := buildDeleteRequest(t, "/upload",
+			map[string]string{"path": ".tmp/anything"})
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeleteOldFilesRecursiveDir(t *testing.T) {
+	e, tempdir := concurrencyServer(t)
+
+	// Make a non-empty directory whose mtime is well in the past.
+	stale := filepath.Join(tempdir, "stale-dir")
+	require.NoError(t, os.MkdirAll(stale, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stale, "inside.txt"), []byte("x"), 0o644))
+
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	req := buildDeleteRequest(t, "/delete", map[string]string{
+		"path":      "",
+		"days":      "1",
+		"recursive": "true",
+	})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code, rec.Body.String())
+
+	_, err := os.Stat(stale)
+	require.Truef(t, os.IsNotExist(err), "stale dir should be removed, got err=%v", err)
+}
+
+func TestDeleteOldFilesSkipsStagingDir(t *testing.T) {
+	e, tempdir := concurrencyServer(t)
+
+	stage := filepath.Join(tempdir, stagingDir)
+	require.NoError(t, os.MkdirAll(stage, 0o755))
+
+	// Make staging look "old".
+	old := time.Now().Add(-365 * 24 * time.Hour)
+	require.NoError(t, os.Chtimes(stage, old, old))
+
+	req := buildDeleteRequest(t, "/delete", map[string]string{
+		"path":      "",
+		"days":      "0",
+		"recursive": "true",
+	})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code, rec.Body.String())
+
+	_, err := os.Stat(stage)
+	require.NoError(t, err, "staging dir must survive the sweep")
+}

--- a/uploader/perms_test.go
+++ b/uploader/perms_test.go
@@ -1,0 +1,151 @@
+package uploader
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const skipOnWindows = "windows"
+
+func withStagingDir(t *testing.T) string {
+	t.Helper()
+	return withStagingDirAt(t, t.TempDir())
+}
+
+func withStagingDirAt(t *testing.T, dir string) string {
+	t.Helper()
+
+	originalDir := directory
+
+	require.NoError(t, setUploadDirectory(dir))
+
+	t.Cleanup(func() {
+		_ = setUploadDirectory(originalDir)
+	})
+
+	return dir
+}
+
+func TestSetupStagingDir_CreatesMissing(t *testing.T) {
+	dir := withStagingDir(t)
+
+	require.NoError(t, setupStagingDir())
+
+	info, err := os.Stat(filepath.Join(dir, stagingDir))
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+func TestSetupStagingDir_WidensRestrictivePerms(t *testing.T) {
+	if runtime.GOOS == skipOnWindows {
+		t.Skip("Unix perms only")
+	}
+
+	dir := withStagingDir(t)
+
+	stage := filepath.Join(dir, stagingDir)
+	require.NoError(t, os.MkdirAll(stage, 0o700))
+
+	require.NoError(t, setupStagingDir())
+
+	info, err := os.Stat(stage)
+	require.NoError(t, err)
+	assert.Equalf(t, os.FileMode(0o755), info.Mode().Perm(),
+		"setupStagingDir must widen owned .tmp/ to 0755")
+}
+
+func TestSetupStagingDir_FailsOnUnwritableParent(t *testing.T) {
+	if runtime.GOOS == skipOnWindows {
+		t.Skip("Unix perms only")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses DAC perms; can't simulate unwritable parent")
+	}
+
+	parent := t.TempDir()
+	require.NoError(t, os.Chmod(parent, 0o500)) // r-x: we can stat, can't write
+
+	t.Cleanup(func() {
+		// Restore so t.TempDir cleanup can remove it.
+		_ = os.Chmod(parent, 0o700)
+	})
+
+	withStagingDirAt(t, parent)
+
+	err := setupStagingDir()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), parent, "error must name the offending directory")
+	assert.Contains(t, err.Error(), "UPLOADER_DIRECTORY", "error must reference the env var operators set")
+}
+
+func TestSweepStagingOrphans_RemovesOnlyKnownPrefixes(t *testing.T) {
+	dir := withStagingDir(t)
+	stage := filepath.Join(dir, stagingDir)
+	require.NoError(t, os.MkdirAll(stage, 0o755))
+
+	orphans := []string{"up-aaaa", "tar-bbbb", "old-cccc"}
+	keepers := []string{"my-debug-file.txt", "manual-backup", "README"}
+
+	for _, n := range orphans {
+		require.NoError(t, os.WriteFile(filepath.Join(stage, n), []byte("x"), 0o644))
+	}
+
+	for _, n := range keepers {
+		require.NoError(t, os.WriteFile(filepath.Join(stage, n), []byte("y"), 0o644))
+	}
+
+	sweepStagingOrphans(stage)
+
+	for _, n := range orphans {
+		_, err := os.Stat(filepath.Join(stage, n))
+		assert.Truef(t, errors.Is(err, os.ErrNotExist), "orphan %s should be removed", n)
+	}
+
+	for _, n := range keepers {
+		_, err := os.Stat(filepath.Join(stage, n))
+		assert.NoErrorf(t, err, "non-orphan %s must be preserved", n)
+	}
+}
+
+func TestPublishFile_ProducesMode0644(t *testing.T) {
+	if runtime.GOOS == skipOnWindows {
+		t.Skip("Unix perms only")
+	}
+
+	dir := withStagingDir(t)
+	require.NoError(t, setupStagingDir())
+
+	require.NoError(t, publishFile(filepath.Join(dir, "out.bin"), bytes.NewReader([]byte("hello"))))
+
+	info, err := os.Stat(filepath.Join(dir, "out.bin"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+func TestExtractTarGz_PublishedDirIs0755(t *testing.T) {
+	if runtime.GOOS == skipOnWindows {
+		t.Skip("Unix perms only")
+	}
+
+	e, tempdir := concurrencyServer(t)
+
+	req := buildUploadRequest(t, "out-dir", makeTarGz(t, "X", 1), "true")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equalf(t, http.StatusCreated, rec.Code, "upload failed: %s", rec.Body.String())
+
+	info, err := os.Stat(filepath.Join(tempdir, "out-dir"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}

--- a/uploader/publish.go
+++ b/uploader/publish.go
@@ -1,0 +1,264 @@
+package uploader
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Hidden by hideStagingFS so clients can't observe in-flight uploads.
+const (
+	stagingDir       = ".tmp"
+	stagingDirPrefix = stagingDir + "/"
+)
+
+// Returned by swapPaths on non-Linux or when the filesystem (NFS, old kernels)
+// rejects RENAME_EXCHANGE; callers fall back to the two-step rename.
+var errSwapUnsupported = errors.New("atomic path exchange not supported")
+
+func isStagingPath(p string) bool {
+	trimmed := strings.TrimPrefix(filepath.ToSlash(p), "/")
+	return trimmed == stagingDir || strings.HasPrefix(trimmed, stagingDirPrefix)
+}
+
+func reserveStagingName(prefix string) (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("failed to generate staging name: %w", err)
+	}
+
+	return filepath.Join(absStagePath, prefix+hex.EncodeToString(b[:])), nil
+}
+
+// Only entries with these prefixes are swept on startup; anything else in
+// .tmp/ is assumed to be human-placed and preserved.
+var stagingArtifactPrefixes = []string{"up-", "tar-", "old-"}
+
+func looksLikeStagingArtifact(name string) bool {
+	for _, p := range stagingArtifactPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ensureParentDir(p string) error {
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return fmt.Errorf("create parent: %w", err)
+	}
+
+	return nil
+}
+
+// Fail fast at startup so misconfigured pods crash with a clear log instead
+// of 500ing on the first upload. Error messages name UPLOADER_DIRECTORY and
+// the relevant k8s knobs so operators can diagnose without reading code.
+func setupStagingDir() error {
+	stage := absStagePath
+
+	if err := os.MkdirAll(stage, 0o755); err != nil {
+		return fmt.Errorf("create staging dir %s: %w "+
+			"(verify UPLOADER_DIRECTORY is writable by the pod user; in Kubernetes "+
+			"set securityContext.fsGroup to match runAsGroup so the PVC is chowned correctly)",
+			stage, err)
+	}
+
+	const wantedStageMode = os.FileMode(0o755)
+
+	if info, err := os.Stat(stage); err == nil {
+		if info.Mode().Perm() != wantedStageMode {
+			if chmodErr := os.Chmod(stage, wantedStageMode); chmodErr != nil {
+				log.Printf("staging dir %s has perms %#o; chmod to %#o failed: %v "+
+					"(likely owned by a different UID — the write probe below "+
+					"will fail with a clearer error if uploads can't proceed)",
+					stage, info.Mode().Perm(), wantedStageMode, chmodErr)
+			}
+		}
+	}
+
+	sentinel := filepath.Join(stage, ".krci-cache-write-probe")
+	if err := os.WriteFile(sentinel, nil, 0o600); err != nil {
+		return fmt.Errorf("staging dir %s exists but is not writable: %w "+
+			"(check that the pod's runAsUser owns it, or that fsGroup matches; "+
+			"if readOnlyRootFilesystem=true, ensure UPLOADER_DIRECTORY points at a writable volume)",
+			stage, err)
+	}
+
+	_ = os.Remove(sentinel)
+
+	sweepStagingOrphans(stage)
+
+	return nil
+}
+
+func sweepStagingOrphans(stage string) {
+	entries, err := os.ReadDir(stage)
+	if err != nil {
+		log.Printf("staging sweep: read %s: %v", stage, err)
+		return
+	}
+
+	removed := 0
+
+	for _, e := range entries {
+		if !looksLikeStagingArtifact(e.Name()) {
+			continue
+		}
+
+		full := filepath.Join(stage, e.Name())
+		if err := os.RemoveAll(full); err != nil {
+			log.Printf("staging sweep: failed to remove %s: %v", full, err)
+			continue
+		}
+
+		removed++
+	}
+
+	if removed > 0 {
+		log.Printf("staging sweep: reclaimed %d orphaned entries from previous runs", removed)
+	}
+}
+
+// Atomically replaces dst with the bytes from r via temp file + rename(2).
+// Concurrent publishers race on the rename; last write wins, no torn bytes.
+func publishFile(dst string, r io.Reader) error {
+	if err := ensureParentDir(dst); err != nil {
+		return err
+	}
+
+	f, err := os.CreateTemp(absStagePath, "up-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+
+	tmpPath := f.Name()
+	committed := false
+
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	// CreateTemp's 0600 default would break sidecars/backups running as other UIDs.
+	if err := f.Chmod(0o644); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+
+	if _, err := io.Copy(f, r); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return fmt.Errorf("publish rename: %w", err)
+	}
+
+	committed = true
+
+	return nil
+}
+
+// Replaces dst with stage atomically. Last-publisher-wins; uses
+// RENAME_EXCHANGE on Linux and a two-step rename elsewhere. The two-step
+// path retries on ENOTEMPTY/EEXIST when a concurrent publisher slots in
+// between our move-aside and our rename.
+func publishDir(dst, stage string) error {
+	if err := ensureParentDir(dst); err != nil {
+		return err
+	}
+
+	const maxAttempts = 8
+
+	backoff := time.Millisecond
+
+	var lastErr error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err := tryPublishDir(dst, stage)
+		if err == nil {
+			return nil
+		}
+
+		if !isPublishRaceError(err) {
+			return err
+		}
+
+		lastErr = err
+
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+
+	return fmt.Errorf("publish gave up after %d attempts: %w", maxAttempts, lastErr)
+}
+
+func tryPublishDir(dst, stage string) error {
+	switch err := swapPaths(stage, dst); {
+	case err == nil:
+		go removeAllLogged(stage)
+		return nil
+	case errors.Is(err, errSwapUnsupported), errors.Is(err, syscall.ENOENT):
+		// Fall through to two-step rename: dst doesn't exist yet, or the
+		// kernel/filesystem doesn't support RENAME_EXCHANGE.
+	default:
+		return err
+	}
+
+	aside, err := reserveStagingName("old-")
+	if err != nil {
+		return err
+	}
+
+	if err := os.Rename(dst, aside); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("move aside: %w", err)
+		}
+
+		aside = ""
+	}
+
+	if err := os.Rename(stage, dst); err != nil {
+		if aside != "" {
+			if restoreErr := os.Rename(aside, dst); restoreErr != nil {
+				log.Printf("publishDir: failed to restore %s: %v (publish err: %v)", dst, restoreErr, err)
+			}
+		}
+
+		return err
+	}
+
+	if aside != "" {
+		go removeAllLogged(aside)
+	}
+
+	return nil
+}
+
+func isPublishRaceError(err error) bool {
+	return errors.Is(err, syscall.ENOTEMPTY) ||
+		errors.Is(err, syscall.EEXIST) ||
+		errors.Is(err, syscall.ENOTDIR)
+}
+
+func removeAllLogged(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.Printf("publish cleanup: failed to remove %s: %v", path, err)
+	}
+}

--- a/uploader/staticfs.go
+++ b/uploader/staticfs.go
@@ -1,0 +1,36 @@
+package uploader
+
+import (
+	"net/http"
+	"os"
+)
+
+// Hides the staging dir from static serving and refuses directory opens
+// (so http.FileServer cannot render listings).
+type hideStagingFS struct {
+	root http.FileSystem
+}
+
+func (fs hideStagingFS) Open(name string) (http.File, error) {
+	if isStagingPath(name) {
+		return nil, os.ErrNotExist
+	}
+
+	f, err := fs.root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	if info.IsDir() {
+		_ = f.Close()
+		return nil, os.ErrNotExist
+	}
+
+	return f, nil
+}

--- a/uploader/swap_linux.go
+++ b/uploader/swap_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package uploader
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Atomically exchanges a and b via renameat2(RENAME_EXCHANGE). Returns
+// errSwapUnsupported when the kernel (<3.15) or filesystem (NFS) rejects
+// the flag so the caller can fall back to a two-step rename.
+func swapPaths(a, b string) error {
+	err := unix.Renameat2(unix.AT_FDCWD, a, unix.AT_FDCWD, b, unix.RENAME_EXCHANGE)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP) {
+		return errSwapUnsupported
+	}
+
+	return err
+}

--- a/uploader/swap_other.go
+++ b/uploader/swap_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package uploader
+
+// swapPaths is unavailable on non-Linux platforms; publishDir falls back to
+// the two-step rename path. Present so tests run on macOS/Windows.
+func swapPaths(_, _ string) error {
+	return errSwapUnsupported
+}

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -6,7 +6,6 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"log"
 	"mime/multipart"
@@ -27,15 +26,14 @@ var (
 	host      = "localhost"
 	port      = "8080"
 	directory = "./pub"
-	// absRootDir is the resolved absolute form of `directory`, cached at startup
-	// so the per-request hot path (safeJoin) does no Abs syscalls. Always update
-	// it via setUploadDirectory to keep the two vars consistent.
+	// Resolved absolute form of `directory`, cached so the per-request hot
+	// path does no Abs syscalls. Always update via setUploadDirectory.
 	absRootDir string
+	// Staging dir; must live on the same filesystem as absRootDir for
+	// rename(2) to be atomic.
+	absStagePath string
 )
 
-// setUploadDirectory updates both `directory` and the cached `absRootDir` so
-// safeJoin sees a consistent view. Returns an error if the path cannot be
-// resolved to an absolute form.
 func setUploadDirectory(dir string) error {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
@@ -44,14 +42,21 @@ func setUploadDirectory(dir string) error {
 
 	directory = dir
 	absRootDir = abs
+	absStagePath = filepath.Join(abs, stagingDir)
 
 	return nil
 }
 
 // safeJoin resolves rel inside the upload directory and returns its absolute
 // path. The trailing-separator check in isPathSafe rejects sibling-prefix
-// escapes such as "/data" vs "/data-evil".
+// escapes such as "/data" vs "/data-evil". Paths that target the staging
+// directory (".tmp/...") are rejected because that dir holds in-flight
+// uploads that users must not observe or mutate.
 func safeJoin(rel string) (string, error) {
+	if isStagingPath(rel) {
+		return "", echo.NewHTTPError(http.StatusForbidden, "DENIED: path is reserved")
+	}
+
 	abspath := filepath.Join(absRootDir, rel)
 
 	if !isPathSafe(abspath, absRootDir) {
@@ -97,11 +102,7 @@ func upload(c echo.Context) error {
 	})
 }
 
-func extractTarGz(file *multipart.FileHeader, abspath string) error {
-	if err := os.MkdirAll(abspath, 0o755); err != nil {
-		return err
-	}
-
+func extractTarGz(file *multipart.FileHeader, finalPath string) error {
 	src, err := file.Open()
 	if err != nil {
 		return err
@@ -113,10 +114,39 @@ func extractTarGz(file *multipart.FileHeader, abspath string) error {
 		}
 	}()
 
-	return UntarGz(abspath, src)
+	stage, err := os.MkdirTemp(absStagePath, "tar-*")
+	if err != nil {
+		return fmt.Errorf("create staging dir: %w", err)
+	}
+
+	// MkdirTemp's 0700 default would break sidecars/backups running as other UIDs.
+	if err := os.Chmod(stage, 0o755); err != nil {
+		removeAllLogged(stage)
+		return fmt.Errorf("chmod staging dir: %w", err)
+	}
+
+	committed := false
+
+	defer func() {
+		if !committed {
+			removeAllLogged(stage)
+		}
+	}()
+
+	if err := UntarGz(stage, src); err != nil {
+		return err
+	}
+
+	if err := publishDir(finalPath, stage); err != nil {
+		return err
+	}
+
+	committed = true
+
+	return nil
 }
 
-func saveRegularFile(file *multipart.FileHeader, abspath string) error {
+func saveRegularFile(file *multipart.FileHeader, finalPath string) error {
 	src, err := file.Open()
 	if err != nil {
 		return err
@@ -128,28 +158,19 @@ func saveRegularFile(file *multipart.FileHeader, abspath string) error {
 		}
 	}()
 
-	if err := os.MkdirAll(filepath.Dir(abspath), 0o755); err != nil {
-		return err
-	}
-
-	dst, err := os.Create(abspath)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if closeErr := dst.Close(); closeErr != nil {
-			log.Printf("error closing destination file: %v", closeErr)
-		}
-	}()
-
-	_, err = io.Copy(dst, src)
-
-	return err
+	return publishFile(finalPath, src)
 }
 
 func uploaderDelete(c echo.Context) error {
 	path := c.FormValue("path")
+
+	// Reject empty path explicitly: safeJoin("") resolves to the upload root.
+	// Without this guard, a DELETE with a missing or unparseable body (e.g.
+	// urlencoded body on DELETE, which net/http does not parse) would wipe
+	// the entire cache directory.
+	if path == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "path is required")
+	}
 
 	abspath, err := safeJoin(path)
 	if err != nil {
@@ -234,8 +255,19 @@ func deleteOldFilesOfDir(c echo.Context) error {
 
 	for _, file := range files {
 		filePath := filepath.Join(abspath, file.Name())
-		if err := os.Remove(filePath); err != nil {
-			log.Printf("failed to delete file %s: %v", file.Name(), err)
+
+		// recursive=true allows directory entries; for those we must use
+		// RemoveAll because Remove fails on non-empty dirs. This restores
+		// the reference behavior that a prior refactor lost.
+		var rmErr error
+		if recursive && file.IsDir() {
+			rmErr = os.RemoveAll(filePath)
+		} else {
+			rmErr = os.Remove(filePath)
+		}
+
+		if rmErr != nil {
+			log.Printf("failed to delete %s: %v", file.Name(), rmErr)
 			continue
 		}
 
@@ -261,7 +293,15 @@ func findFilesOlderThanXDays(dir string, days int, recursive bool) (files []os.F
 		return nil, err
 	}
 
+	// Skip the staging dir when sweeping the upload root so a misconfigured
+	// cron (path="", recursive=true, days=0) can't wipe in-flight uploads.
+	skipStaging := dir == absRootDir
+
 	for _, file := range tmpfiles {
+		if skipStaging && file.Name() == stagingDir {
+			continue
+		}
+
 		info, err := file.Info()
 		if err != nil {
 			continue
@@ -341,6 +381,16 @@ func loadConfig() (serverConfig, error) {
 	return cfg, nil
 }
 
+// Shared between Uploader() and the test server so route registration cannot drift.
+func registerRoutes(e *echo.Echo, fileServer http.Handler) {
+	e.GET(healthPath, healthCheck)
+	e.HEAD("/:path", lastModified)
+	e.POST("/upload", upload)
+	e.DELETE("/upload", uploaderDelete)
+	e.DELETE("/delete", deleteOldFilesOfDir)
+	e.GET("/*", echo.WrapHandler(fileServer))
+}
+
 // registerAuth mirrors go-simple-uploader: only mutating endpoints require creds.
 // rawCreds is assumed validated by loadConfig (contains ":"). The expected
 // username/password are converted to bytes once so the per-request validator is
@@ -412,24 +462,30 @@ func Uploader() error {
 		return err
 	}
 
+	if err := setupStagingDir(); err != nil {
+		return err
+	}
+
+	// The multipart parser spools parts >32MB into os.TempDir(); on
+	// readOnlyRootFilesystem pods the default /tmp is unwritable so every
+	// large upload would fail with EROFS. Point TMPDIR at our writable PVC.
+	if err := os.Setenv("TMPDIR", absStagePath); err != nil {
+		log.Printf("failed to set TMPDIR=%s: %v (multipart spool may fail on readOnlyRootFilesystem pods)", absStagePath, err)
+	}
+
 	e := echo.New()
 	e.HideBanner = true
 	e.Server.ReadHeaderTimeout = readHeaderTimeout
 	e.Server.IdleTimeout = idleTimeout
 
-	// Recover first so it catches panics in any later middleware. Logger wraps
-	// BodyLimit so 413 rejections are still logged.
+	// Recover first so it catches panics in later middleware; Logger wraps
+	// BodyLimit so 413s are still logged.
 	e.Use(middleware.Recover())
 	e.Use(middleware.Logger())
 	e.Use(middleware.BodyLimit(cfg.maxUploadSize))
 	registerAuth(e, cfg.credentials)
 
-	e.Static("/", directory)
-	e.GET(healthPath, healthCheck)
-	e.HEAD("/:path", lastModified)
-	e.POST("/upload", upload)
-	e.DELETE("/upload", uploaderDelete)
-	e.DELETE("/delete", deleteOldFilesOfDir)
+	registerRoutes(e, http.FileServer(hideStagingFS{root: http.Dir(absRootDir)}))
 
 	addr := fmt.Sprintf("%s:%s", host, port)
 	log.Printf("krci-cache listening on %s (directory=%s, max_upload=%s, shutdown_timeout=%s)",

--- a/uploader/uploader_test.go
+++ b/uploader/uploader_test.go
@@ -1,4 +1,3 @@
-// Package uploader provides HTTP upload server functionality with support for file uploads and tar.gz extraction.
 package uploader
 
 import (
@@ -8,48 +7,16 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// setupTestServer creates a minimal test server for the simplified implementation
-func setupTestServer(t *testing.T) (*echo.Echo, string) {
-	// Create temp directory
-	tempdir, err := os.MkdirTemp("", "uploader-test-*")
-	require.NoError(t, err)
-
-	originalDir := directory
-
-	require.NoError(t, setUploadDirectory(tempdir))
-
-	e := echo.New()
-	e.Use(middleware.Logger())
-	e.Use(middleware.Recover())
-
-	e.Static("/", directory)
-	e.GET("/health", healthCheck)
-	e.HEAD("/:path", lastModified)
-	e.POST("/upload", upload)
-	e.DELETE("/upload", uploaderDelete)
-	e.DELETE("/delete", deleteOldFilesOfDir)
-
-	t.Cleanup(func() {
-		_ = setUploadDirectory(originalDir)
-
-		os.RemoveAll(tempdir)
-	})
-
-	return e, tempdir
-}
-
 func TestHealthCheck(t *testing.T) {
-	e, _ := setupTestServer(t)
+	e, _ := concurrencyServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
@@ -63,75 +30,27 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestUploadSimpleFile(t *testing.T) {
-	e, tempdir := setupTestServer(t)
+	e, tempdir := concurrencyServer(t)
 
-	// Create multipart form
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-
-	// Add file part
-	part, err := writer.CreateFormFile("file", "test.txt")
-	require.NoError(t, err)
-	_, err = part.Write([]byte("test content"))
-	require.NoError(t, err)
-
-	// Add path field
-	err = writer.WriteField("path", "test.txt")
-	require.NoError(t, err)
-
-	err = writer.Close()
-	require.NoError(t, err)
-
-	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/upload", body)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-
+	req := buildUploadRequest(t, "test.txt", []byte("test content"), "")
 	rec := httptest.NewRecorder()
-
-	// Execute request
 	e.ServeHTTP(rec, req)
 
-	// Check response
 	assert.Equal(t, http.StatusCreated, rec.Code)
 	assert.Contains(t, rec.Body.String(), "File has been uploaded to")
 
-	// Verify file was created
-	filePath := filepath.Join(tempdir, "test.txt")
-	content, err := os.ReadFile(filePath)
+	content, err := os.ReadFile(filepath.Join(tempdir, "test.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "test content", string(content))
 }
 
 func TestUploadDirectoryTraversal(t *testing.T) {
-	e, _ := setupTestServer(t)
+	e, _ := concurrencyServer(t)
 
-	// Create multipart form with malicious path
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-
-	// Add file part
-	part, err := writer.CreateFormFile("file", "test.txt")
-	require.NoError(t, err)
-	_, err = part.Write([]byte("malicious content"))
-	require.NoError(t, err)
-
-	// Add malicious path field
-	err = writer.WriteField("path", "../../../../../../etc/passwd")
-	require.NoError(t, err)
-
-	err = writer.Close()
-	require.NoError(t, err)
-
-	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/upload", body)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-
+	req := buildUploadRequest(t, "../../../../../../etc/passwd", []byte("malicious content"), "")
 	rec := httptest.NewRecorder()
-
-	// Execute request
 	e.ServeHTTP(rec, req)
 
-	// Should be forbidden
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.Contains(t, rec.Body.String(), "DENIED")
 }
@@ -183,30 +102,40 @@ func TestUploadSiblingPrefixTraversal(t *testing.T) {
 }
 
 func TestDeleteFile(t *testing.T) {
-	e, tempdir := setupTestServer(t)
+	e, tempdir := concurrencyServer(t)
 
-	// Create a test file
 	testFile := filepath.Join(tempdir, "delete-me.txt")
-	err := os.WriteFile(testFile, []byte("delete this"), 0644)
-	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(testFile, []byte("delete this"), 0644))
 
-	// Create delete request
-	body := strings.NewReader("path=delete-me.txt")
-	req := httptest.NewRequest(http.MethodDelete, "/upload", body)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
+	req := buildDeleteRequest(t, "/upload", map[string]string{"path": "delete-me.txt"})
 	rec := httptest.NewRecorder()
-
-	// Execute request
 	e.ServeHTTP(rec, req)
 
-	// Check response
 	assert.Equal(t, http.StatusAccepted, rec.Code)
 	assert.Contains(t, rec.Body.String(), "has been deleted")
 
-	// Verify file was deleted
-	_, err = os.Stat(testFile)
+	_, err := os.Stat(testFile)
 	assert.True(t, os.IsNotExist(err))
+}
+
+// TestDeleteRejectsEmptyPath pins down the security guard that prevents a
+// missing or unparseable form body from accidentally wiping the cache root.
+// Without the guard, the previous behavior was: empty path -> safeJoin
+// returns the upload directory itself -> RemoveAll deletes everything.
+func TestDeleteRejectsEmptyPath(t *testing.T) {
+	e, tempdir := concurrencyServer(t)
+
+	// Seed a file so we'd notice if the root got wiped.
+	require.NoError(t, os.WriteFile(filepath.Join(tempdir, "guard.txt"), []byte("keep"), 0o644))
+
+	req := buildDeleteRequest(t, "/upload", map[string]string{"path": ""})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	_, err := os.Stat(filepath.Join(tempdir, "guard.txt"))
+	assert.NoError(t, err, "upload root must not be wiped by an empty-path DELETE")
 }
 
 // saveServerGlobals snapshots the package-level `directory`, `host`, and


### PR DESCRIPTION
Single-file uploads now write to a temp file in .tmp/ then atomically rename into place. Tar extractions write to a staging directory, then publish via renameat2(RENAME_EXCHANGE) on Linux or two-step rename elsewhere (retrying on transient race errors). The staging directory is hidden from static serves and swept of known orphans at startup.

Pod-perms hardening: chmod 0644 on published files, 0755 on dirs, and TMPDIR redirect so multipart bodies spool to the PVC on read-only-filesystem pods.

Security: safeJoin rejects .tmp/* paths; empty-path DELETE returns 400 (preventing accidental root wipe).

Bugfix: recursive delete now uses RemoveAll for directories.
