### PR TITLE
feat: honor request context in publish operations and optimize tar extraction

### DIFF
--- a/uploader/publish.go
+++ b/uploader/publish.go
@@ -1,6 +1,7 @@
 package uploader
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -192,7 +193,11 @@ func publishFile(dst string, r io.Reader) error {
 // RENAME_EXCHANGE on Linux and a two-step rename elsewhere. The two-step
 // path retries on ENOTEMPTY/EEXIST when a concurrent publisher slots in
 // between our move-aside and our rename.
-func publishDir(dst, stage string) error {
+//
+// The retry loop honors ctx so a disconnected HTTP client (CI worker
+// timeout, pipeline cancellation) doesn't keep the server burning cycles
+// on a doomed publish.
+func publishDir(ctx context.Context, dst, stage string) error {
 	if err := ensureParentDir(dst); err != nil {
 		return err
 	}
@@ -204,7 +209,7 @@ func publishDir(dst, stage string) error {
 	var lastErr error
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		err := tryPublishDir(dst, stage)
+		err := tryPublishDir(ctx, dst, stage)
 		if err == nil {
 			return nil
 		}
@@ -215,14 +220,26 @@ func publishDir(dst, stage string) error {
 
 		lastErr = err
 
-		time.Sleep(backoff)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+
 		backoff *= 2
 	}
 
 	return fmt.Errorf("publish gave up after %d attempts: %w", maxAttempts, lastErr)
 }
 
-func tryPublishDir(dst, stage string) error {
+func tryPublishDir(ctx context.Context, dst, stage string) error {
+	// Skip an attempted rename when the client has already disconnected;
+	// avoids a partial move-aside that the retry loop would then have to
+	// undo.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	switch err := swapPaths(stage, dst); {
 	case err == nil:
 		go removeAllLogged(stage)

--- a/uploader/publish_test.go
+++ b/uploader/publish_test.go
@@ -1,0 +1,91 @@
+package uploader
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// publishDir's retry loop fires on ENOTEMPTY/EEXIST/ENOTDIR — race outcomes
+// of the move-aside-then-rename sequence on non-Linux fallback. We trigger
+// it deterministically by stripping the staging dir so the move-aside step
+// silently no-ops via fs.ErrNotExist; the subsequent rename(stage, dst)
+// then hits a still-existing non-empty dst and returns the race error.
+func TestPublishDirHonorsContextCancelMidRetry(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		// On Linux, swapPaths uses RENAME_EXCHANGE which atomically swaps
+		// in one syscall — the retry loop is never entered. The retry-with-
+		// cancel path is exercised on the !linux fallback below.
+		t.Skip("retry loop only fires on the non-Linux fallback path")
+	}
+
+	base := t.TempDir()
+	require.NoError(t, setUploadDirectory(base))
+	// Intentionally do NOT call setupStagingDir(): without absStagePath on
+	// disk, reserveStagingName produces a path whose parent is missing, so
+	// the move-aside rename returns ENOENT and the code treats it as
+	// "nothing to move". rename(stage, dst) then races against a non-empty
+	// dst and reliably returns ENOTEMPTY.
+
+	dst := filepath.Join(base, "dst")
+	require.NoError(t, os.MkdirAll(dst, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "marker"), []byte("x"), 0o644))
+
+	stage := filepath.Join(base, "stage")
+	require.NoError(t, os.MkdirAll(stage, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stage, "y"), []byte("y"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Fire well before the cumulative backoff (1+2+4+8+16+32+64+128 = 255ms)
+	// would otherwise complete on its own.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := publishDir(ctx, dst, stage)
+	elapsed := time.Since(start)
+
+	require.Truef(t, errors.Is(err, context.Canceled),
+		"expected context.Canceled, got %v", err)
+
+	// Without honoring ctx, publishDir would burn ~255ms in time.Sleep.
+	// 100ms is comfortably above 5ms scheduling jitter and well below 255ms.
+	assert.Lessf(t, elapsed, 100*time.Millisecond,
+		"publishDir did not exit promptly on cancel: took %v", elapsed)
+}
+
+// Pre-canceled context: tryPublishDir's ctx.Err() guard short-circuits
+// before any syscalls fire, so publishDir returns immediately without
+// even attempting the rename.
+func TestPublishDirHonorsCanceledContextImmediately(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, setUploadDirectory(base))
+	require.NoError(t, setupStagingDir())
+
+	dst := filepath.Join(base, "dst")
+	stage := filepath.Join(base, "stage")
+	require.NoError(t, os.MkdirAll(stage, 0o755))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := publishDir(ctx, dst, stage)
+	require.Truef(t, errors.Is(err, context.Canceled),
+		"expected context.Canceled, got %v", err)
+
+	// The successful-publish path would have moved stage onto dst; verify
+	// it didn't.
+	_, statErr := os.Stat(dst)
+	assert.Truef(t, errors.Is(statErr, os.ErrNotExist),
+		"publish should not have happened, but dst exists")
+}

--- a/uploader/untar.go
+++ b/uploader/untar.go
@@ -34,7 +34,12 @@ func UntarGz(dst string, r io.Reader) error {
 	// Track actual bytes written instead of header-declared sizes
 	var totalWritten int64
 
-	return extractArchive(tr, absDst, &totalWritten)
+	// Cache of parent dirs already ensured during this extraction. Bounded
+	// by archive contents (~50B * unique-dir-count) and freed on return.
+	// Eliminates the per-entry MkdirAll fan-out that costs ~1ms/call on NFS.
+	ensuredDirs := make(map[string]struct{})
+
+	return extractArchive(tr, absDst, &totalWritten, ensuredDirs)
 }
 
 // setupExtraction prepares the destination and gzip reader
@@ -60,7 +65,11 @@ func closeGzipReader(gzr *gzip.Reader) {
 }
 
 // extractArchive processes the tar archive entries
-func extractArchive(tr *tar.Reader, absDst string, totalWritten *int64) error {
+func extractArchive(tr *tar.Reader, absDst string, totalWritten *int64, ensuredDirs map[string]struct{}) error {
+	// Pre-seed: absDst is created by the caller of UntarGz before extraction,
+	// so files whose parent is the root skip a redundant MkdirAll.
+	ensuredDirs[absDst] = struct{}{}
+
 	for {
 		header, err := tr.Next()
 
@@ -73,7 +82,6 @@ func extractArchive(tr *tar.Reader, absDst string, totalWritten *int64) error {
 			continue
 		}
 
-		// Pre-validate individual file size limit
 		if header.Size > MaxFileSize {
 			return fmt.Errorf("file %s exceeds maximum size limit (%d bytes)", header.Name, MaxFileSize)
 		}
@@ -83,7 +91,7 @@ func extractArchive(tr *tar.Reader, absDst string, totalWritten *int64) error {
 			return fmt.Errorf("unsafe path detected: %s", header.Name)
 		}
 
-		if err := processEntry(header, target, tr, totalWritten); err != nil {
+		if err := processEntry(header, target, tr, totalWritten, ensuredDirs); err != nil {
 			return err
 		}
 	}
@@ -99,15 +107,17 @@ func validateTotalSize(totalWritten int64, additionalBytes int64) error {
 }
 
 // processEntry handles different tar entry types
-func processEntry(header *tar.Header, target string, tr *tar.Reader, totalWritten *int64) error {
+func processEntry(header *tar.Header, target string, tr *tar.Reader, totalWritten *int64, ensuredDirs map[string]struct{}) error {
 	switch header.Typeflag {
 	case tar.TypeDir:
 		if err := handleDirectory(target, header); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", header.Name, err)
 		}
 
+		ensuredDirs[target] = struct{}{}
+
 	case tar.TypeReg:
-		written, err := handleRegularFile(target, header, tr, *totalWritten)
+		written, err := handleRegularFile(target, header, tr, *totalWritten, ensuredDirs)
 		if err != nil {
 			return fmt.Errorf("failed to extract file %s: %w", header.Name, err)
 		}
@@ -131,21 +141,13 @@ func isPathSafe(absTarget, absRoot string) bool {
 	return absTarget == absRoot || strings.HasPrefix(absTarget, absRoot+string(filepath.Separator))
 }
 
-// handleDirectory creates a directory with proper permissions
+// handleDirectory creates a directory with proper permissions.
+// MkdirAll is idempotent on an existing directory and surfaces a clear
+// ENOTDIR if the path exists as a file — no separate Stat needed.
 func handleDirectory(target string, header *tar.Header) error {
-	// Check if directory already exists
-	if info, err := os.Stat(target); err == nil {
-		if !info.IsDir() {
-			return fmt.Errorf("path exists but is not a directory: %s", target)
-		}
-
-		return nil // Directory already exists
-	}
-
-	// Create directory with permissions from tar header, but ensure minimum safety
 	mode := os.FileMode(header.Mode) & os.ModePerm
 	if mode == 0 {
-		mode = 0755 // Default safe permissions
+		mode = 0755
 	}
 
 	return os.MkdirAll(target, mode)
@@ -153,13 +155,16 @@ func handleDirectory(target string, header *tar.Header) error {
 
 // handleRegularFile extracts a regular file with proper resource management
 // Returns the actual number of bytes written
-func handleRegularFile(target string, header *tar.Header, tr *tar.Reader, currentTotal int64) (int64, error) {
-	// Ensure parent directory exists
-	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-		return 0, fmt.Errorf("failed to create parent directory: %w", err)
+func handleRegularFile(target string, header *tar.Header, tr *tar.Reader, currentTotal int64, ensuredDirs map[string]struct{}) (int64, error) {
+	parent := filepath.Dir(target)
+	if _, ok := ensuredDirs[parent]; !ok {
+		if err := os.MkdirAll(parent, 0755); err != nil {
+			return 0, fmt.Errorf("failed to create parent directory: %w", err)
+		}
+
+		ensuredDirs[parent] = struct{}{}
 	}
 
-	// Create file with permissions from tar header
 	mode := os.FileMode(header.Mode) & os.ModePerm
 	if mode == 0 {
 		mode = 0644 // Default safe permissions for files
@@ -176,16 +181,13 @@ func handleRegularFile(target string, header *tar.Header, tr *tar.Reader, curren
 		}
 	}()
 
-	// Use a tracking writer to monitor actual bytes written
 	trackingWriter := &trackingWriter{
 		writer:       f,
 		currentTotal: currentTotal,
 	}
 
-	// Copy directly from tar reader with streaming size validation
 	written, err := io.Copy(trackingWriter, tr)
 	if err != nil {
-		// Clean up partial file on error
 		_ = os.Remove(target)
 		return 0, fmt.Errorf("failed to write file content: %w", err)
 	}
@@ -207,7 +209,6 @@ type trackingWriter struct {
 }
 
 func (tw *trackingWriter) Write(p []byte) (int, error) {
-	// Check if writing this chunk would exceed total size limit
 	if err := validateTotalSize(tw.currentTotal+tw.written, int64(len(p))); err != nil {
 		return 0, err
 	}

--- a/uploader/untar_bench_test.go
+++ b/uploader/untar_bench_test.go
@@ -1,0 +1,150 @@
+// Tar-extraction microbenchmarks for the dir-cache change in extractArchive.
+// Per-entry savings come from skipping a redundant MkdirAll on a parent dir
+// already ensured by a prior entry, so the absolute win scales with the
+// number of regular-file entries that share a parent.
+//
+// To compare against a baseline commit:
+//
+//	git worktree add /tmp/baseline <rev>
+//	cp uploader/untar_bench_test.go /tmp/baseline/uploader/
+//	go test -C /tmp/baseline -run='^$' -bench=BenchmarkUntarGz -benchtime=3x ./uploader/
+//	go test -run='^$' -bench=BenchmarkUntarGz -benchtime=3x ./uploader/
+//
+// On Linux ext4/xfs the win per skipped MkdirAll is ~3-5us; on NFS it's ~1ms.
+package uploader
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Single-dir archive: all entries share one parent, so the dir cache turns
+// N-1 redundant MkdirAll calls into N-1 map hits.
+func BenchmarkUntarGzManyFilesSingleDir(b *testing.B) {
+	for _, entries := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("entries=%d", entries), func(b *testing.B) {
+			arc := buildSingleDirArchive(b, entries)
+			runUntarBench(b, arc)
+		})
+	}
+}
+
+// Wide archive: each entry has its own parent dir, so the cache only saves
+// the per-entry parent lookup against the implicit-root entry — minimal win.
+// Establishes the lower bound and guards against regression on this shape.
+func BenchmarkUntarGzManyFilesUniqueDirs(b *testing.B) {
+	for _, entries := range []int{100, 1000} {
+		b.Run(fmt.Sprintf("entries=%d", entries), func(b *testing.B) {
+			arc := buildUniqueDirArchive(b, entries)
+			runUntarBench(b, arc)
+		})
+	}
+}
+
+func runUntarBench(b *testing.B, arc []byte) {
+	b.Helper()
+
+	b.SetBytes(int64(len(arc)))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+
+		dst, err := os.MkdirTemp("", "untar-bench-*")
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.StartTimer()
+
+		if err := UntarGz(dst, bytes.NewReader(arc)); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+
+		_ = os.RemoveAll(dst)
+	}
+}
+
+func buildSingleDirArchive(b *testing.B, entries int) []byte {
+	b.Helper()
+
+	var buf bytes.Buffer
+
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	const payloadSize = 64
+
+	payload := make([]byte, payloadSize)
+
+	for i := 0; i < entries; i++ {
+		hdr := &tar.Header{
+			Name:     fmt.Sprintf("flat/entry-%05d.bin", i),
+			Mode:     0o644,
+			Size:     int64(payloadSize),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			b.Fatal(err)
+		}
+
+		if _, err := tw.Write(payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	if err := gw.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	return buf.Bytes()
+}
+
+func buildUniqueDirArchive(b *testing.B, entries int) []byte {
+	b.Helper()
+
+	var buf bytes.Buffer
+
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	const payloadSize = 64
+
+	payload := make([]byte, payloadSize)
+
+	for i := 0; i < entries; i++ {
+		hdr := &tar.Header{
+			Name:     fmt.Sprintf("dir-%05d/file.bin", i),
+			Mode:     0o644,
+			Size:     int64(payloadSize),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			b.Fatal(err)
+		}
+
+		if _, err := tw.Write(payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	if err := gw.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	return buf.Bytes()
+}

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -151,7 +151,7 @@ func upload(c echo.Context) error {
 		return err
 	}
 
-	if err := publishConsumed(abspath, stagedTmp, stagedDir, wantTarGz(fields)); err != nil {
+	if err := publishConsumed(c.Request().Context(), abspath, stagedTmp, stagedDir, wantTarGz(fields)); err != nil {
 		return err
 	}
 
@@ -183,12 +183,12 @@ func resolveDestination(fields map[string]string, filename string) (string, stri
 	return resolvedPath, abspath, nil
 }
 
-func publishConsumed(abspath, stagedTmp, stagedDir string, tarGz bool) error {
+func publishConsumed(ctx context.Context, abspath, stagedTmp, stagedDir string, tarGz bool) error {
 	switch {
 	case stagedDir != "":
-		return publishDir(abspath, stagedDir)
+		return publishDir(ctx, abspath, stagedDir)
 	case tarGz:
-		return extractStagedTempToDir(stagedTmp, abspath)
+		return extractStagedTempToDir(ctx, stagedTmp, abspath)
 	default:
 		return publishStaged(stagedTmp, abspath)
 	}
@@ -300,7 +300,7 @@ func streamTarToStageDir(r io.Reader) (string, int64, error) {
 
 // Late-path tar fallback: the file part arrived before targz=true was known,
 // so we already streamed it to a temp file and now have to extract it.
-func extractStagedTempToDir(stagedPath, finalPath string) error {
+func extractStagedTempToDir(ctx context.Context, stagedPath, finalPath string) error {
 	src, err := os.Open(stagedPath)
 	if err != nil {
 		return fmt.Errorf("open staged: %w", err)
@@ -322,7 +322,7 @@ func extractStagedTempToDir(stagedPath, finalPath string) error {
 		return err
 	}
 
-	if err := publishDir(finalPath, stage); err != nil {
+	if err := publishDir(ctx, finalPath, stage); err != nil {
 		removeAllLogged(stage)
 		return err
 	}


### PR DESCRIPTION
Respect HTTP request context cancellation in publish and extract operations, allowing CI workers to interrupt long-running operations without wasting server resources. Implement a directory cache in tar extraction to eliminate redundant MkdirAll calls on already-ensured parent directories, reducing latency on NFS (approximately 1ms per skipped call).

