### PR TITLE
fix: update rsync pin to 3.4.3-r0 to unblock Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.title="krci-cache" \
 # Install required packages with version pinning
 RUN apk add --no-cache \
     tar=1.35-r4 \
-    rsync=3.4.2-r0 \
+    rsync=3.4.3-r0 \
     && rm -rf /var/cache/apk/*
 
 # Copy the pre-built binary from dist folder


### PR DESCRIPTION
Alpine 3.23 repositories advanced rsync from 3.4.2-r0 to 3.4.3-r0, making the old exact pin unselectable and breaking `apk add` during the image build. Bump the pinned revision to the currently published version to restore builds.
