### PR TITLE
EPMDEDP-17194: ci: automate changelog, release notes, and commit validation

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,60 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,64 @@
+style: none
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/KubeRocketCI/krci-cache
+
+options:
+  tag_filter_pattern: '^v'
+  sort: "semVer"
+
+  commits:
+    filters:
+      Type:
+        - feat
+        - fix
+        - perf
+        - refactor
+        - style
+        - test
+        - docs
+        - ci
+        - build
+        - deps
+        - chore
+
+  commit_groups:
+    group_by: Type
+    sort_by: Custom
+    title_order:
+      - feat
+      - fix
+      - perf
+      - refactor
+      - style
+      - test
+      - docs
+      - ci
+      - build
+      - deps
+      - chore
+    title_maps:
+      feat: Features
+      fix: Bug Fixes
+      perf: Performance Improvements
+      refactor: Code Refactoring
+      style: Formatting
+      test: Testing
+      docs: Documentation
+      ci: CI
+      build: Build
+      deps: Dependencies
+      chore: Routine
+
+  header:
+    # Matches optional Jira prefix (e.g. "EPMDEDP-123: "), a conventional-commit
+    # type, an optional scope like "(deps)", and an optional "!" breaking marker.
+    pattern: "^(?:[A-Z]+-\\d+:\\s)?(\\w+)(?:\\(.+?\\))?!?:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+
+  notes:
+    keywords:
+      - "BREAKING CHANGE:"

--- a/.chglog/release.tpl.md
+++ b/.chglog/release.tpl.md
@@ -1,0 +1,29 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,49 @@
+name: Commit Message Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-commit-message:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check commit format
+        uses: gsactions/commit-message-checker@v2
+        with:
+          # Human commits MUST carry a Jira ID: "EPMDEDP-<ID>: <type>: <desc>".
+          # The only exception is Dependabot bumps, which cannot reference a
+          # ticket (krci-cache Dependabot emits "deps(deps): bump ..." and
+          # "ci: bump ...").
+          pattern: '^(EPMDEDP-\d+: (build|chore|ci|docs|feat|fix|perf|refactor|style|test)(!)?: .+|(build|chore|ci|deps)(\(deps\))?: [Bb]ump .+)$'
+          error: 'Commit title must be "EPMDEDP-<ID>: <type>: <description>" (Jira ID is mandatory). Example: "EPMDEDP-16058: feat: add feature".'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check commit title length
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^.{10,85}$'
+          error: 'Commit title must be between 10 and 85 characters long.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,51 @@
+name: Create KRCI release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  GO_VERSION: '1.25.8'
+  GITCHGLOG_VERSION: 'v0.15.4'
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-release:
+    name: Perform automatic release on trigger ${{ github.ref }}
+    runs-on: ubuntu-latest
+    env:
+      # The name of the tag as supplied by the GitHub event, e.g. refs/tags/v0.3.0
+      SOURCE_TAG: ${{ github.ref }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Generate release notes
+        run: |
+          set -xue
+
+          # refs/tags/v0.3.0 -> v0.3.0
+          RELEASE_TAG="${SOURCE_TAG##*/}"
+
+          go install github.com/git-chglog/git-chglog/cmd/git-chglog@${GITCHGLOG_VERSION}
+
+          git-chglog --template .chglog/release.tpl.md -o release.md "${RELEASE_TAG}"
+
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_TAG }}
+          body_path: release.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,107 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+### Bug Fixes
+
+- update rsync pin to 3.4.3-r0 to unblock Docker build
+
+### Documentation
+
+- streamline CLAUDE.md
+
+### CI
+
+- bump actions/checkout from 6 to 7
+
+### Dependencies
+
+- bump golang.org/x/sys in the go-stdlib group
+- bump golang.org/x/net from 0.54.0 to 0.55.0
+- bump golang.org/x/crypto from 0.45.0 to 0.52.0
+- bump golang.org/x/sys in the go-stdlib group
+- bump golang.org/x/sys in the go-stdlib group
+- bump golang.org/x/sys in the go-stdlib group
+
+
+<a name="v0.2.0"></a>
+## v0.2.0 - 2026-05-21
+### Features
+
+- honor request context in publish operations and optimize tar extraction
+- stream multipart uploads to eliminate disk write amplification
+- implement atomic publish with last-writer-wins concurrency safety
+- add production-ready high-performance features for pipeline cache
+
+### Bug Fixes
+
+- prevent OOM by limiting multipart form memory to 32MB
+
+### Performance Improvements
+
+- optimize memory usage in tar.gz extraction and HTTP server
+
+### Code Refactoring
+
+- consolidate uploader server configuration and handlers
+- Simplify code to ensure lower memory usage
+
+### Testing
+
+- Add checks for e2e tests
+- Tune e2e tests
+- Add e2e simple tests
+
+### Documentation
+
+- Update README by adding use-cases
+
+### CI
+
+- implement branch-sha and semver-based image tagging for releases
+- bump docker/build-push-action from 6 to 7
+- bump docker/setup-qemu-action from 3 to 4
+- bump docker/metadata-action from 5 to 6
+- bump docker/setup-buildx-action from 3 to 4
+- bump docker/login-action from 3 to 4
+- bump actions/upload-artifact from 6 to 7
+- bump actions/upload-artifact from 5 to 6
+- bump actions/checkout from 5 to 6
+- bump actions/upload-artifact from 4 to 5
+- bump github/codeql-action from 3 to 4
+- bump actions/setup-go from 5 to 6
+- bump actions/checkout from 4 to 5
+
+### Dependencies
+
+- bump golang.org/x/crypto from 0.38.0 to 0.45.0
+- bump github.com/stretchr/testify from 1.11.0 to 1.11.1
+- bump github.com/stretchr/testify from 1.10.0 to 1.11.0
+
+### Routine
+
+- Update alpine version to 3.23
+- Update rsync package version in Dockerfile
+- update base image version in Dockerfile
+- Setup KubeRocketAI ([#25](https://github.com/KubeRocketCI/krci-cache/issues/25))
+- Implement semver tag versioning ([#20](https://github.com/KubeRocketCI/krci-cache/issues/20))
+- Align Dockerfile args for multi-arch build support ([#18](https://github.com/KubeRocketCI/krci-cache/issues/18))
+- Add CODEOWNERS
+- Add cache for pipelines
+- Use kubectl exec instead of spinning pod each time in e2e
+- Switch to alpine image
+- Add security advisory
+- Add community attributes
+- Update untar approach
+- Update golang version
+- Update build pipeline
+- Update README.md file
+- Simplify PR workflow
+- Fix build pipeline
+- Update build flow to support multi-arch
+- Add sonarqube configuration
+- Update project structure
+- update golangci.yml configuration
+- update dependencies
+
+
+[Unreleased]: https://github.com/KubeRocketCI/krci-cache/compare/v0.2.0...HEAD

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ GOLANGCI_LINT_VERSION ?= v2.8.0
 CHAINSAW_VERSION ?= v0.2.12
 KIND_VERSION ?= v0.29.0
 KUSTOMIZE_VERSION ?= v5.6.0
+GITCHGLOG_VERSION ?= v0.15.4
 
 # Kind cluster configuration
 KUBE_VERSION ?= 1.32
@@ -57,6 +58,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 CHAINSAW ?= $(LOCALBIN)/chainsaw
 KIND ?= $(LOCALBIN)/kind
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
+GITCHGLOG ?= $(LOCALBIN)/git-chglog
 
 .PHONY: install-tools
 install-tools: golangci-lint chainsaw kind kustomize ## Download all tools locally if necessary
@@ -97,6 +99,20 @@ test-coverage: test ## Run tests and generate coverage report
 .PHONY: test-short
 test-short: ## Run tests in short mode
 	go test -short -v ./...
+
+# use https://github.com/git-chglog/git-chglog/
+.PHONY: changelog
+changelog: git-chglog ## Generate CHANGELOG.md from conventional commits
+ifneq (${NEXT_RELEASE_TAG},)
+	$(GITCHGLOG) --next-tag v${NEXT_RELEASE_TAG} -o CHANGELOG.md
+else
+	$(GITCHGLOG) -o CHANGELOG.md
+endif
+
+.PHONY: git-chglog
+git-chglog: $(GITCHGLOG) ## Download git-chglog locally if necessary
+$(GITCHGLOG): $(LOCALBIN)
+	$(call go-install-tool,$(GITCHGLOG),github.com/git-chglog/git-chglog/cmd/git-chglog,$(GITCHGLOG_VERSION))
 
 build: $(DIST_DIR) ## Build the binary file following EDP pattern
 	CGO_ENABLED=0 GOOS=${HOST_OS} GOARCH=${HOST_ARCH} go build -v \


### PR DESCRIPTION


- Add git-chglog config and templates to generate CHANGELOG.md and per-tag release notes from conventional commits
- Add release workflow that publishes a GitHub Release on v* tags
- Add PR workflow enforcing mandatory Jira-prefixed conventional commit titles
- Add `make changelog` target and pin the git-chglog tool version
- Generate the initial CHANGELOG.md from existing history
